### PR TITLE
Fix error EmptyStaticCreds: static credentials are empty

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,7 +62,12 @@ func loadConfigFile(path string) *Config {
 
 	// fmt.Println("Read config ", path)
 
-	if err := ini.MapTo(config, path); err != nil {
+	cfg, err := ini.Load(path)
+	if err != nil {
+		return config
+	}
+
+	if err := cfg.Section("default").MapTo(config); err != nil {
 		return config
 	}
 


### PR DESCRIPTION
Extract credentials from "default" section of ini file